### PR TITLE
Fix some typo in method names

### DIFF
--- a/GCTagList/ViewController.m
+++ b/GCTagList/ViewController.m
@@ -97,8 +97,8 @@
     
     [self.tagNames insertObject:@"Girls' Generation" atIndex:index];
     [self.tagNames insertObject:@"TaeTiSeo" atIndex:index];
-//    [tagList insertTagLabelWithRagne:NSMakeRange(index, 2)];
-    [tagList insertTagLabelWithRagne:NSMakeRange(index, 2) withAnimation:YES];
+//    [tagList insertTagLabelWithRange:NSMakeRange(index, 2)];
+    [tagList insertTagLabelWithRange:NSMakeRange(index, 2) withAnimation:YES];
     
 //    [tagList reloadData];
 }

--- a/GCTagList/classes/GCTagList.h
+++ b/GCTagList/classes/GCTagList.h
@@ -160,11 +160,11 @@ typedef NS_ENUM(NSInteger, GCTagLabelAccessoryType) {
 /**
  *  insert taglabel with range.
  */
-- (void)insertTagLabelWithRagne:(NSRange)range;
+- (void)insertTagLabelWithRange:(NSRange)range;
 
 - (void)reloadTagLabelWithRange:(NSRange)range withAnimation:(BOOL)animated;
 - (void)deleteTagLabelWithRange:(NSRange)range withAnimation:(BOOL)animated;
-- (void)insertTagLabelWithRagne:(NSRange)range withAnimation:(BOOL)animated;
+- (void)insertTagLabelWithRange:(NSRange)range withAnimation:(BOOL)animated;
 
 @end
 

--- a/GCTagList/classes/GCTagList.m
+++ b/GCTagList/classes/GCTagList.m
@@ -243,11 +243,11 @@
     
 }
 
-- (void)insertTagLabelWithRagne:(NSRange)range {
-    [self insertTagLabelWithRagne:range withAnimation:NO];
+- (void)insertTagLabelWithRange:(NSRange)range {
+    [self insertTagLabelWithRange:range withAnimation:NO];
 }
 
-- (void)insertTagLabelWithRagne:(NSRange)range withAnimation:(BOOL)animated {
+- (void)insertTagLabelWithRange:(NSRange)range withAnimation:(BOOL)animated {
     if(![self checkImplementDataSourceRequireMehtod])
         return;
     


### PR DESCRIPTION
In the last commit I corrected a typo in the Readme.md. When I started to use the component found a typo in the code and also corrected.
